### PR TITLE
fix: ensure schemas are packaged for both sdist and bdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include iglu_client/schemas *

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/jbwyme/iglu-python-client",
     packages=setuptools.find_packages(),
+    include_package_data=True,
     license_file="LICENSE-2.0.txt",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Hi @jbwyme, thanks for this client!

I tried to use yesterday, and realized it was not working since the bootstrap schemas were not included with the package. I believe this change should ensure that they will be included and available for the embedded registry, for both source and binary distributions. With the change, I was able to run your sample code in the README.